### PR TITLE
Fix: Use ${node_bin} for the node binary

### DIFF
--- a/LSP-elm.sublime-settings
+++ b/LSP-elm.sublime-settings
@@ -1,4 +1,5 @@
 {
+	"command": ["${node_bin}", "${server_path}", "--stdio"],
 	"languages": [
 		{
 			"languageId": "elm",

--- a/plugin.py
+++ b/plugin.py
@@ -16,7 +16,3 @@ class LspElmPlugin(NpmClientHandler):
     server_binary_path = os.path.join(
         server_directory, 'node_modules', '@elm-tooling', 'elm-language-server', 'out', 'index.js'
     )
-
-    @classmethod
-    def install_in_cache(cls) -> bool:
-        return False

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,19 @@
+# Tox (http://tox.testrun.org/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py3
+skipsdist = True
+
+[pycodestyle]
+max-line-length = 120
+
+[flake8]
+ignore =
+    F841  # local variable is assigned to but never used
+    E252  # missing whitespace around parameter equals
+    W504  # line break after binary operator
+    F821  # undefined name
+max-line-length = 120


### PR DESCRIPTION
With the latest version of lsp_utils a change was introduced [1] that allows using a locally
managed node runtime instead of the system one. For that to work, the "node" command
needs to use a variable.

[1] https://github.com/sublimelsp/lsp_utils/commit/403345a0c5c15e84802c712044c630a9fb236b9d