### PR TITLE
refactor: replace deprecated initializationOptions with initialization_options

### DIFF
--- a/LSP-elm.sublime-settings
+++ b/LSP-elm.sublime-settings
@@ -1,6 +1,6 @@
 {
 	"command": ["${node_bin}", "${server_path}", "--stdio"],
-	"initializationOptions": {
+	"initialization_options": {
 		"trace.server": "off",
 		"elmPath": "",
 		"elmReviewPath": "",

--- a/sublime-package.json
+++ b/sublime-package.json
@@ -10,7 +10,7 @@
                     "definitions": {
                         "PluginConfig": {
                             "properties": {
-                                "initializationOptions": {
+                                "initialization_options": {
                                     "type": "object",
                                     "additionalProperties": false,
                                     "properties": {


### PR DESCRIPTION
In https://github.com/sublimelsp/LSP/releases/tag/4070-2.9.0 `config.init_options`
and `initializationOptions` in settings were deprecated.

(This is a semi-automatically created PR that might not
have been tested manually.)
